### PR TITLE
Fix missing API base URL

### DIFF
--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -1,6 +1,9 @@
 import axios from 'axios';
 
-const BASE_URL = import.meta.env.VITE_API_BASE_URL;
+// Use environment variable if provided, otherwise default to `/api`
+// so the frontend works out of the box during local development.
+const BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
+
 const api = axios.create({
     baseURL: BASE_URL,
 });


### PR DESCRIPTION
## Summary
- default the Axios baseURL to `/api` when the environment variable isn't set

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*