### PR TITLE
Add log parser tests

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "main": "server.js",
   "scripts": {
     "start": "nodemon server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node ./test/logParser.test.js"
   },
   "type": "module",
   "keywords": [],

--- a/server/test/logParser.test.js
+++ b/server/test/logParser.test.js
@@ -1,0 +1,25 @@
+import assert from 'assert';
+import { parseLogFile } from '../src/utils/logParser.js';
+
+const logData = [
+  '{"user":"john","timestamp":"2024-01-01T00:00:00Z","text":"hello"}',
+  'invalid json',
+  '{"user":"jane","timestamp":"2024-01-01T00:00:01Z","text":"hi"}'
+].join('\n');
+
+const result = parseLogFile(logData);
+assert.strictEqual(Array.isArray(result), true, 'parseLogFile should return an array');
+assert.strictEqual(result.length, 2, 'Should ignore invalid JSON lines');
+assert.deepStrictEqual(result[0], {
+  user: 'john',
+  timestamp: '2024-01-01T00:00:00Z',
+  text: 'hello'
+});
+assert.deepStrictEqual(result[1], {
+  user: 'jane',
+  timestamp: '2024-01-01T00:00:01Z',
+  text: 'hi'
+});
+
+console.log('All tests passed');
+


### PR DESCRIPTION
## Summary
- add a minimal test for `parseLogFile`
- wire `npm test` to run the new test

## Testing
- `npm --prefix server test`
